### PR TITLE
Avoid temporary strings in SubstVar.

### DIFF
--- a/apt-pkg/contrib/strutl.cc
+++ b/apt-pkg/contrib/strutl.cc
@@ -464,7 +464,9 @@ string SubstVar(const string &Str,const string &Subst,const string &Contents)
 
    if (OldPos >= Str.length())
       return Temp;
-   return Temp + string(Str,OldPos);
+
+   Temp.append(Str, OldPos, string::npos);
+   return Temp;
 }
 string SubstVar(string Str,const struct SubstVar *Vars)
 {


### PR DESCRIPTION
Microoptimization, but still gives a measurable 2-3% improvement
when using commands with lots of output like `apt list`.
