### PR TITLE
Bugfix/sha1 deprecated

### DIFF
--- a/apt-pkg/contrib/hashes.cc
+++ b/apt-pkg/contrib/hashes.cc
@@ -142,8 +142,17 @@ APT_PURE bool HashString::usable() const				/*{{{*/
    return (
       (Type != "Checksum-FileSize") &&
       (Type != "MD5Sum") &&
-      (Type != "SHA1") &&
       !IsConfigured(Type.c_str(), "Untrusted")
+   );
+}
+
+APT_PURE bool HashString::deprecated() const				/*{{{*/
+{
+   return (
+      (Type == "Checksum-FileSize") ||
+      (Type == "MD5Sum") ||
+      (Type == "SHA1") ||
+      IsConfigured(Type.c_str(), "Weak")
    );
 }
 									/*}}}*/
@@ -176,6 +185,12 @@ bool HashStringList::usable() const					/*{{{*/
       return false;
    }
    return find(forcedType) != NULL;
+}
+bool HashStringList::deprecated() const					/*{{{*/
+{
+   return std::all_of(list.begin(), list.end(), [](HashString const &hs) {
+      return hs.deprecated() || !hs.usable();
+   });
 }
 									/*}}}*/
 HashString const * HashStringList::find(char const * const type) const /*{{{*/

--- a/apt-pkg/contrib/hashes.h
+++ b/apt-pkg/contrib/hashes.h
@@ -69,6 +69,7 @@ class HashString
    std::string toStr() const;                    // convert to str as "type:hash"
    bool empty() const;
    bool usable() const;
+   bool deprecated() const APT_HIDDEN;
    bool operator==(HashString const &other) const;
    bool operator!=(HashString const &other) const;
 
@@ -141,6 +142,11 @@ class HashStringList
     * if one is forced \b true if this has is available, \b false otherwise
     */
    bool usable() const;
+   /** are all entries deprecated
+    *
+    * Do not use.
+    */
+   bool deprecated() const;
 
    typedef std::vector<HashString>::const_iterator const_iterator;
 

--- a/apt-pkg/deb/debmetaindex.cc
+++ b/apt-pkg/deb/debmetaindex.cc
@@ -395,6 +395,7 @@ bool debReleaseIndex::Load(std::string const &Filename, std::string * const Erro
 
    bool FoundHashSum = false;
    bool FoundStrongHashSum = false;
+   bool AllDeprecatedHashSum = true;
    auto const SupportedHashes = HashString::SupportedHashes();
    for (int i=0; SupportedHashes[i] != NULL; i++)
    {
@@ -421,6 +422,8 @@ bool debReleaseIndex::Load(std::string const &Filename, std::string * const Erro
          }
          Entries[Name]->Hashes.push_back(hs);
          FoundHashSum = true;
+	 if (AllDeprecatedHashSum == true && hs.deprecated() == false)
+	    AllDeprecatedHashSum = false;
 	 if (FoundStrongHashSum == false && hs.usable() == true)
 	    FoundStrongHashSum = true;
       }
@@ -437,6 +440,10 @@ bool debReleaseIndex::Load(std::string const &Filename, std::string * const Erro
       if (ErrorText != NULL)
 	 strprintf(*ErrorText, _("No Hash entry in Release file %s which is considered strong enough for security purposes"), Filename.c_str());
       return false;
+   }
+   else if(AllDeprecatedHashSum == true)
+   {
+      _error->Warning(_("No Hash entry in Release file %s which is considered strong enough for security purposes"), Filename.c_str());
    }
 
    std::string const StrDate = Section.FindS("Date");

--- a/apt-private/private-source.cc
+++ b/apt-private/private-source.cc
@@ -434,7 +434,7 @@ bool DoSource(CommandLine &CmdL)
 	    }
 
 	 // see if we have a hash (Acquire::ForceHash is the only way to have none)
-	 if (I->Hashes.usable() == false && _config->FindB("APT::Get::AllowUnauthenticated",false) == false)
+	 if ((I->Hashes.usable() == false || I->Hashes.deprecated() == true) && _config->FindB("APT::Get::AllowUnauthenticated",false) == false)
 	 {
 	    ioprintf(c1out, "Skipping download of file '%s' as requested hashsum is not available for authentication\n",
 		  localFile.c_str());

--- a/test/libapt/hashsums_test.cc
+++ b/test/libapt/hashsums_test.cc
@@ -298,6 +298,7 @@ TEST(HashSumsTest, FileBased)
 TEST(HashSumsTest, HashStringList)
 {
    _config->Clear("Acquire::ForceHash");
+   _config->Set("APT::Hashes::SHA1::Untrusted", "yes");
 
    HashStringList list;
    EXPECT_TRUE(list.empty());


### PR DESCRIPTION
This marks SHA1 as usable again, but also marks it as deprecated and issues warnings about indices, and requires packages and sources to be used with --allow-unauthenticated.
