### PR TITLE
Improve GetLocalitySortedVersionSet, speeds up apt search by 30%

### DIFF
--- a/apt-pkg/contrib/strutl.cc
+++ b/apt-pkg/contrib/strutl.cc
@@ -71,14 +71,14 @@ bool Endswith(const std::string &s, const std::string &end)
 {
    if (end.size() > s.size())
       return false;
-   return (s.substr(s.size() - end.size(), s.size()) == end);
+   return (s.compare(s.size() - end.size(), end.size(), end) == 0);
 }
 
 bool Startswith(const std::string &s, const std::string &start)
 {
    if (start.size() > s.size())
       return false;
-   return (s.substr(0, start.size()) == start);
+   return (s.compare(0, start.size(), start) == 0);
 }
 
 }


### PR DESCRIPTION
Feel free to nitpick or adapt the patch.

In `GetLocalitySortedVersionSet`, `std::set<pkgCache::VerIterator, VersionSortDescriptionLocality>` did a lot of repeated work in `TranslatedDescription`: http://puu.sh/oM4nU/e7d8c9a039.svg

This change stores the DescFile pointer in the set to avoid repeated calls.

Only two commands use `LocalitySortedVersionSet`:

| command | old | new |
| --- | --- | --- |
| time ./apt search cppformat | 1.032s | 0.747s |
| time ./apt list > /dev/null | 1.230s | 0.960s |

Also, a small unrelated change in `Startswith` and `Endswith` that avoids string allocation since we can just call `.compare()`.
